### PR TITLE
Make rocks toml file detection support symlinks and add toml-edit dep

### DIFF
--- a/ftplugin/toml.lua
+++ b/ftplugin/toml.lua
@@ -2,7 +2,7 @@ local ok, rocks = pcall(require, "rocks.api")
 
 assert(ok, "rocks.nvim is required for `rocks-edit.nvim` to function, please install it!")
 
-if vim.fn.expand("%") == rocks.get_rocks_toml_path() then
+if vim.uv.fs_realpath(vim.fn.expand("%")) == vim.uv.fs_realpath(rocks.get_rocks_toml_path()) then
     local rocks_edit = require("rocks-edit")
 
     rocks_edit.display_diagnostics(vim.api.nvim_get_current_buf())

--- a/rocks-edit.nvim-scm-1.rockspec
+++ b/rocks-edit.nvim-scm-1.rockspec
@@ -10,6 +10,7 @@ dependencies = {
     "lua >= 5.1",
     "nvim-nio ~> 1",
     "rocks.nvim >= 2.35.0",
+    "toml-edit >= 0.4.1",
 }
 
 test_dependencies = {


### PR DESCRIPTION
Currently, the rocks toml file detection doesn't work if you are using a symlink (ex. from a dotfiles repo) and also the use of `vim.fn.expand("%")` will return the buffer path relative to the cwd meaning that the absolute path returned by the `rocks.api` function will most likely not match the path of the current buffer in most cases.

Another issue I saw is that rocks-edit.nvim uses toml-edit and is dependent on the `parse_spanned` function which wasn't introduced till version `0.4.0` (bug fixed in `0.4.1`). Though this is implicitly pulled in by rocks.nvim which is a dependency of rocks-edit, the version that is pulled in by rocks.nvim is an older version and so it doesn't have the `parse_spanned` function. We should maybe declare an explicit dependency for toml-edit since a newer version is need. Don't know if this is the best solution here but just wanted to highlight it here.